### PR TITLE
Add next CaenCamp event

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,3 +10,5 @@ current_dojo:
   subtitle: Ruby on Rails
   date: courant février
 timezone: Europe/Paris
+future: true
+excerpt_separator: <!-- more -->

--- a/_includes/post.html
+++ b/_includes/post.html
@@ -30,8 +30,8 @@
       </div>
       <div class="post_content">
         {% if page.is_index %}
-          {% if include.post.summary %}
-            {{ include.post.summary }}
+          {% if include.excerpt %}
+            {{ include.post.excerpt }}
           {% else %}
             {{ include.post.content }}
           {% endif %}

--- a/_posts/2017-03-28-caencamp-28-le-graphql-c-est-vraiment-la-fin-du-rest.md
+++ b/_posts/2017-03-28-caencamp-28-le-graphql-c-est-vraiment-la-fin-du-rest.md
@@ -10,6 +10,8 @@ Alexis Janvier fera une intervention sur le GraphQL: parfois présenté comme le
 successeur des API Rest, le graphQL fait briller les yeux de nombreux
 développeurs. Mais est-ce que c'est aussi bon que ça ?
 
+<!-- more -->
+
 ## C'est pour qui ?
 
 Cette session est ouverte à tous.

--- a/_posts/2017-04-25-caencamp-29-architecture-flux-alternative-au-mvc.md
+++ b/_posts/2017-04-25-caencamp-29-architecture-flux-alternative-au-mvc.md
@@ -1,0 +1,27 @@
+---
+title: "CaenCamp #29 : Architecture flux : Alternative au MVC ?"
+layout: post
+author: Clément Lebiez
+author_link: https://twitter.com/clebiez
+date: 2017-04-25T18:30:00+0200
+---
+
+Clément Lebiez viendra nous parler de *Flux*.
+
+> Flux n'est pas un framework, mais plutôt une architecture, une façon de penser permettant de résoudre les problèmes de scalabilité et de maintenance que l'on peut rencontrer dans le développement d'applications webs volumineuses.
+> Nous aborderons la mise en place d'un projet front-end en utilisant l'architecture Flux pour en tirer ses avantages et ses inconvénients.
+> Cette architecture nouvelle, propulsé par Facebook avec son framework JavaScript React est-elle une alternative prometteuse au MVC traditionnel ? 
+
+<!-- more -->
+
+## C'est pour qui ?
+
+Cette session est ouverte à tous.
+
+## Ça se passe où ?
+
+Le lieu n'est pas encore validé.
+
+## Je veux venir !
+
+Inscrivez-vous sur MeetUp : [#29 Architecture flux : Alternative au MVC ?](https://www.meetup.com/CaenCamp/events/239134605/).

--- a/_posts/2017-04-25-caencamp-29-architecture-flux-alternative-au-mvc.md
+++ b/_posts/2017-04-25-caencamp-29-architecture-flux-alternative-au-mvc.md
@@ -20,7 +20,7 @@ Cette session est ouverte à tous.
 
 ## Ça se passe où ?
 
-Le lieu n'est pas encore validé.
+Rendez-vous mardi 25 avril à 18h30 au [Forum Digital](http://forum-digital.fr/fr/acces-et-localisation-du-forum-digital-de-caen-colombelles.-gc16.html)
 
 ## Je veux venir !
 

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ layout: home
 
 <div class="container">
   {% for post in paginator.posts %}
-    {% include post.html post=post %}
+    {% include post.html post=post excerpt="true" %}
   {% endfor %}
 </div>
 


### PR DESCRIPTION
On a side note, @alexisjanvier :

* [ ] The [Twitter account bio of the CaenCamp account](https://twitter.com/caencamp) is utterly outdated;
* [ ] The [MeetUp page](https://www.meetup.com/CaenCamp/events/239134605/) references Clément Lebiez's Treelo data… Isn't his Twitter account a better fit?